### PR TITLE
Update index.js

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -60,7 +60,7 @@ class ImmutableStore extends EventEmitter {
     if (store_data === null || typeof store_data !== 'object') {
       throw new Error('Base Store: The first parameter typeof object and not null');
     }
-    this._data = Immutable.Map(store_data);
+    this._data = Immutable.fromJS(store_data);
     this.dispatchToken = LCARS.register((action) => {
       callback(action);
     });


### PR DESCRIPTION
changed immutable store's constructor to use Immutable's fromJS() instead of Map() on the ititial data passed to the store.

this makes it work as expected. with map, it will not recognize changes in nested structures or operate the updateIn method correctly.

alternatively, we can handle it at a more granular level, but i think this is a little redundant since. Unless there is a performant issues doing it the way this pull request suggests, i do not think the below would be a better solution. what do you think?

```
const HelloStore = new ImmutableStore({
    hello: Immutable.Map({
      count: 0
    }),
    someOtherProperty: 1,
    oneMoreForGoodMeasure: Immutable.Map({
      test: 123,
      check: 'one-two'
    })
  },
```

maybe its just late as hell and im missing something. lets chat about it tomorrow.
