### PR TITLE
added isClean(), replaceClean(), and rollback()

### DIFF
--- a/src/Store.js
+++ b/src/Store.js
@@ -9,8 +9,7 @@ class WelpStore extends EventEmitter {
 
   constructor(store_data, callback) {
     super();
-    this._data = this.replace(store_data);
-    this.becameClean();
+    this._data = this.replaceClean(store_data);
     this.dispatchToken = Dispatcher.register((action) => {
       callback(action);
     });
@@ -49,8 +48,8 @@ class WelpStore extends EventEmitter {
   removeChangeListener(callback) {
     this.removeListener(CHANGE_EVENT, callback);
   }
-  becameClean() {
-    this._clean_state = this.data();
+  replaceClean(data) {
+    this._clean_state = this.replace(data);
     return this.data();
   }
   isClean() {

--- a/src/Store.js
+++ b/src/Store.js
@@ -10,6 +10,7 @@ class WelpStore extends EventEmitter {
   constructor(store_data, callback) {
     super();
     this._data = this.replace(store_data);
+    this.becameClean();
     this.dispatchToken = Dispatcher.register((action) => {
       callback(action);
     });
@@ -25,7 +26,7 @@ class WelpStore extends EventEmitter {
     if (Iterable.isIterable(data)) {
       return this._check_data(this._data, data);
     }
-    return this._check_data(this._data, fromJS(data)); 
+    return this._check_data(this._data, fromJS(data));
   }
   data() {
     return this._data;
@@ -47,6 +48,16 @@ class WelpStore extends EventEmitter {
   }
   removeChangeListener(callback) {
     this.removeListener(CHANGE_EVENT, callback);
+  }
+  becameClean() {
+    this._clean_state = this.data();
+    return this.data();
+  }
+  isClean() {
+    return this._clean_state === this._data;
+  }
+  rollback() {
+    return this.replace(this._clean_state);
   }
 }
 

--- a/src/__tests__/Store-test.js
+++ b/src/__tests__/Store-test.js
@@ -115,5 +115,36 @@ describe('WelpStore', () => {
       );
       expect(s.replace(s.data().merge(Immutable.Map({wat: 'wat'}))).toJS()).toEqual({ test: 'test', wat: 'wat' });
     });
+    it('becameClean', () => {
+      const s = new WelpStore(
+        {test: 123},
+        action => action
+      );
+      expect( s._clean_state.toJS() ).toEqual( {test: 123} );
+      s.replace(s.data().set('test', 'passed'));
+      s.becameClean();
+      expect( s._clean_state.toJS() ).toEqual( {test: 'passed'} );
+    });
+    it('isClean', () => {
+      const s = new WelpStore(
+        {test: 123},
+        action => action
+      );
+      expect( s.isClean() ).toEqual( true );
+      s.replace(s.data().set('test', 'passed'));
+      expect( s.isClean() ).toEqual( false );
+    });
+    it('rollback', () => {
+      const s = new WelpStore(
+        {test: 123},
+        action => action
+      );
+      expect( s.data().toJS() ).toEqual( {test: 123} );
+      s.replace(s.data().set('test', 'somethingelse'));
+      expect( s.data().toJS() ).toEqual( {test: 'somethingelse'} );
+      s.rollback();
+      expect( s.data().toJS() ).toEqual( {test: 123} );
+    });
+    
   });
 });

--- a/src/__tests__/Store-test.js
+++ b/src/__tests__/Store-test.js
@@ -115,14 +115,14 @@ describe('WelpStore', () => {
       );
       expect(s.replace(s.data().merge(Immutable.Map({wat: 'wat'}))).toJS()).toEqual({ test: 'test', wat: 'wat' });
     });
-    it('becameClean', () => {
+    it('replaceClean', () => {
       const s = new WelpStore(
         {test: 123},
         action => action
       );
       expect( s._clean_state.toJS() ).toEqual( {test: 123} );
-      s.replace(s.data().set('test', 'passed'));
-      s.becameClean();
+      s.replaceClean(s.data().set('test', 'passed'));
+      expect( s.data().toJS() ).toEqual( {test: 'passed'} );
       expect( s._clean_state.toJS() ).toEqual( {test: 'passed'} );
     });
     it('isClean', () => {


### PR DESCRIPTION
#### added a small state tracking and reversion mechanism.

originally was going to add this on a per store basis, but since this is something that is going to be used pretty much across all stores and it will most likely be used other places that welp is used and it doesnt interfere with the current api, i figured it could make a good addition.

let me know what you think.

replaceClean and rollback examples:

```
...
switch(action.type) {
  case FETCH_ALL_DATA_SUCCESS:
    return Store.replaceClean(action.data);

  case FETCH_PARTIAL_DATA_SUCCESS:
    return Store.replaceClean(Store.data().set('some_data', action.data));

  case REVERT_CHANGES:
    return Store.rollback();
}
...
```

isClean example:

```
Store.isClean();      // true || false
```
