### PR TITLE
fixed bug

### DIFF
--- a/src/Store.js
+++ b/src/Store.js
@@ -21,11 +21,11 @@ class WelpStore extends EventEmitter {
     }
     return this._data;
   }
+  _ensure_immutibility(data) {
+    return Iterable.isIterable(data) ? data : fromJS(data);
+  }
   replace(data) {
-    if (Iterable.isIterable(data)) {
-      return this._check_data(this._data, data);
-    }
-    return this._check_data(this._data, fromJS(data));
+    return this._check_data(this.data(), this._ensure_immutibility(data));
   }
   data() {
     return this._data;
@@ -49,11 +49,11 @@ class WelpStore extends EventEmitter {
     this.removeListener(CHANGE_EVENT, callback);
   }
   replaceClean(data) {
-    this._clean_state = this.replace(data);
-    return this.data();
+    this._clean_state = this._ensure_immutibility(data);
+    return this._check_data(this.data(), this._clean_state);
   }
   isClean() {
-    return this._clean_state === this._data;
+    return JSON.stringify(this._clean_state) === JSON.stringify(this._data);
   }
   rollback() {
     return this.replace(this._clean_state);

--- a/src/__tests__/Store-test.js
+++ b/src/__tests__/Store-test.js
@@ -133,6 +133,8 @@ describe('WelpStore', () => {
       expect( s.isClean() ).toEqual( true );
       s.replace(s.data().set('test', 'passed'));
       expect( s.isClean() ).toEqual( false );
+      s.replaceClean({test: 321});
+      expect( s.isClean() ).toEqual( true );
     });
     it('rollback', () => {
       const s = new WelpStore(
@@ -144,6 +146,16 @@ describe('WelpStore', () => {
       expect( s.data().toJS() ).toEqual( {test: 'somethingelse'} );
       s.rollback();
       expect( s.data().toJS() ).toEqual( {test: 123} );
+    });
+    it('_ensure_immutibility', () => {
+      const s = new WelpStore(
+        {test: 123},
+        action => action
+      );
+      const immutable_object = Immutable.fromJS({test: 123});
+      const mutable_object = {test: 123};
+      expect( Immutable.Iterable.isIterable( s._ensure_immutibility(immutable_object) ) ).toEqual( true );
+      expect( Immutable.Iterable.isIterable( s._ensure_immutibility(mutable_object) ) ).toEqual( true );
     });
     
   });


### PR DESCRIPTION
Fixed small bug that I introduced that was emitting change before updating the clean_state.
also changed the way isClean compares the current state to the new state to determine if a change is present because `Immutable.fromJS({test: 1 }) !== Immutable.fromJS({test: 1})`

external api remains the same, just fixes some internals
